### PR TITLE
fixed md5sum for VBoxGuestAdditions_5.1.12.iso

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -224,7 +224,7 @@ find_ga() {
     local dev_iso="VBoxGuestAdditions_${major_minor_release}.iso"
     local url="http://download.virtualbox.org/virtualbox/${major_minor_release}/${dev_iso}"
     ga_iso="${ievms_home}/${dev_iso}"
-    download "VirtualBox Guest Additions ISO" "${url}" "${ga_iso}" "8cf1af35478905ea29828954ddb2c5ee"
+    download "VirtualBox Guest Additions ISO" "${url}" "${ga_iso}" "54fb52bd79b706a2c8cf520530a527c5"
 }
 
 # Attach a dvd image to the virtual machine.


### PR DESCRIPTION
Quick fix for md5 sum for guest additions ISO in version 5.1.12.

FYI, while the VM was coming up, it was waiting a long time for the guest additions to install, so I manually went into the VM and there was a prompt for `Install`, `Don't Install`. After clicking that things proceeded as normal.